### PR TITLE
Add Jest test and update guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,13 @@ The project follows a simple, no-build-step structure:
 ## Technology Stack
 
 -   **Core Engine**: [Three.js](https://threejs.org/) will be used for 3D rendering.
--   **Loading**: Three.js will be loaded directly from a CDN in `index.html`. No npm/yarn or other package managers are to be used.
+-   **Loading**: Three.js will be loaded directly from a CDN in `index.html`. The game itself does not rely on any build step, though npm is used for running tests.
 
 ## Development Workflow
 
 -   **No Build Step**: The game is designed to run directly in the browser without any compilation or bundling steps.
 -   **Execution**: Open the `index.html` file in a web browser to run the game.
+-   **Testing**: Run `npm test` and fix any errors before committing.
 
 ## Coding Style
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "shootymctoothy",
+  "version": "1.0.0",
+  "description": "ShootyMcToothy browser-based 3D shooter game",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+
+test('main.js parses without errors', () => {
+  const code = fs.readFileSync('assets/js/main.js', 'utf8');
+  expect(() => new Function(code)).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- switch parsing test to use Jest
- include test script in package.json
- clarify development guide to run `npm test`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68711cf064a88323a2ab313c73fb342f