### PR TITLE
Fix pointer lock when game paused

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -370,6 +370,11 @@ function onMouseMove(event) {
 
 // The function to handle mouse down events.
 function onMouseDown(event) {
+    // Do nothing if the game is paused.
+    if (gamePaused) {
+        // Exit early to allow UI clicks.
+        return;
+    }
     // Lock the pointer to the document body.
     document.body.requestPointerLock();
     // Check if the left mouse button was clicked.


### PR DESCRIPTION
## Summary
- avoid capturing mouse when the game is paused

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871445de6e08323af04081fbdff3556