### PR TITLE
Move UI rendering to canvas

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2,10 +2,3 @@ body {
     margin: 0;
     overflow: hidden;
 }
-
-#uiCanvas {
-    position: absolute;
-    top: 0;
-    left: 0;
-    pointer-events: none;
-}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3,86 +3,9 @@ body {
     overflow: hidden;
 }
 
-#score {
+#uiCanvas {
     position: absolute;
-    top: 10px;
-    left: 10px;
-    color: black;
-    font-family: sans-serif;
-    font-size: 2em;
-}
-
-#health {
-    position: absolute;
-    top: 50px;
-    left: 10px;
-    color: black;
-    font-family: sans-serif;
-    font-size: 2em;
-}
-
-#fpsCounter {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    color: black;
-    font-family: sans-serif;
-    font-size: 2em;
-}
-
-#gameOverScreen {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: rgba(0, 0, 0, 0.8);
-    color: white;
-    padding: 20px;
-    border-radius: 10px;
-    text-align: center;
-    font-family: sans-serif;
-}
-
-#gameOverScreen h1 {
-    margin-top: 0;
-}
-
-#gameOverScreen button {
-    padding: 10px 20px;
-    font-size: 1.2em;
-    cursor: pointer;
-}
-
-#highScoresList {
-    list-style: none;
-    padding: 0;
-    margin-top: 10px;
-}
-
-#highScoresList li {
-    padding: 5px 0;
-    border-bottom: 1px solid #ccc;
-}
-
-#startScreen {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: rgba(0, 0, 0, 0.8);
-    color: white;
-    padding: 20px;
-    border-radius: 10px;
-    text-align: center;
-    font-family: sans-serif;
-}
-
-#startScreen h1 {
-    margin-top: 0;
-}
-
-#startScreen button {
-    padding: 10px 20px;
-    font-size: 1.2em;
-    cursor: pointer;
+    top: 0;
+    left: 0;
+    pointer-events: none;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -147,6 +147,8 @@ const uiContext = uiCanvas.getContext('2d');
 let lastFrameTime = 0;
 let frameCount = 0;
 let fps = 0;
+// Variable to store the last time the UI was updated.
+let lastUIUpdate = -1000;
 
 // Variable to track if the game is paused.
 let gamePaused = false;
@@ -512,8 +514,13 @@ function animate(currentTime) {
     if (gamePaused) {
         // Render the scene without updates.
         renderer.render(scene, camera);
-        // Draw the UI overlay.
-        drawUI();
+        // Check if one second has passed since the last UI update.
+        if (currentTime - lastUIUpdate >= 1000) {
+            // Record the time of this UI update.
+            lastUIUpdate = currentTime;
+            // Draw the UI overlay.
+            drawUI();
+        }
         // Exit early to skip game logic.
         return;
     }
@@ -713,8 +720,13 @@ function animate(currentTime) {
 
     // Render the scene from the camera's perspective.
     renderer.render(scene, camera);
-    // Draw the UI overlay after rendering.
-    drawUI();
+    // Update the UI only once per second.
+    if (currentTime - lastUIUpdate >= 1000) {
+        // Record the time of this UI update.
+        lastUIUpdate = currentTime;
+        // Draw the UI overlay.
+        drawUI();
+    }
 }
 
 // Start the animation loop.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -126,32 +126,22 @@ function saveHighScores() {
 
 // Function to display high scores.
 function displayHighScores() {
-    // Get the high scores list element.
-    const highScoresList = document.getElementById('highScoresList');
-    // Clear the current list.
-    highScoresList.innerHTML = '';
-    // Iterate over high scores and create list items.
-    highScores.forEach(scoreEntry => {
-        // Create a new list item.
-        const listItem = document.createElement('li');
-        // Set the text content of the list item.
-        listItem.textContent = `${scoreEntry.name}: ${scoreEntry.score}`;
-        // Append the list item to the list.
-        highScoresList.appendChild(listItem);
-    });
+    // The UI canvas will display the high scores.
+    return highScores.map(scoreEntry => `${scoreEntry.name}: ${scoreEntry.score}`);
 }
 
 // Initialize the score.
 let score = 0;
-// Get the score element.
-const scoreElement = document.getElementById('score');
-
 // Initialize player health.
 let health = 100;
-// Get the health element.
-const healthElement = document.getElementById('health');
-// Get the FPS counter element.
-const fpsCounter = document.getElementById('fpsCounter');
+// Get the UI canvas element.
+const uiCanvas = document.getElementById('uiCanvas');
+// Set the UI canvas size to match the window size.
+uiCanvas.width = window.innerWidth;
+// Set the height of the UI canvas.
+uiCanvas.height = window.innerHeight;
+// Get the 2D drawing context from the UI canvas.
+const uiContext = uiCanvas.getContext('2d');
 
 // Variables for FPS calculation.
 let lastFrameTime = 0;
@@ -160,6 +150,10 @@ let fps = 0;
 
 // Variable to track if the game is paused.
 let gamePaused = false;
+// Variable to track if the game has ended.
+let gameOver = false;
+// Variable to track if the game has started.
+let gameStarted = false;
 // Variable to store the animation frame ID.
 let animationFrameId;
 
@@ -370,9 +364,23 @@ function onMouseMove(event) {
 
 // The function to handle mouse down events.
 function onMouseDown(event) {
+    // Restart the game if it is over.
+    if (gameOver) {
+        // Reload the page to reset the state.
+        location.reload();
+        // Exit because the click triggered a restart.
+        return;
+    }
+    // Start the game if it has not begun.
+    if (!gameStarted) {
+        // Call the startGame function.
+        startGame();
+        // Exit because the click was used to start the game.
+        return;
+    }
     // Do nothing if the game is paused.
     if (gamePaused) {
-        // Exit early to allow UI clicks.
+        // Exit early because input should be ignored.
         return;
     }
     // Lock the pointer to the document body.
@@ -392,6 +400,10 @@ function onWindowResize() {
     camera.updateProjectionMatrix();
     // Set the size of the renderer to the new window size.
     renderer.setSize(window.innerWidth, window.innerHeight);
+    // Update the UI canvas width.
+    uiCanvas.width = window.innerWidth;
+    // Update the UI canvas height.
+    uiCanvas.height = window.innerHeight;
 }
 
 // The function to create a projectile.
@@ -490,8 +502,6 @@ function animate(currentTime) {
     if (currentTime > lastFrameTime + 1000) {
         // Calculate FPS.
         fps = Math.round(frameCount * 1000 / (currentTime - lastFrameTime));
-        // Update FPS counter.
-        fpsCounter.textContent = 'FPS: ' + fps;
         // Reset last frame time.
         lastFrameTime = currentTime;
         // Reset frame count.
@@ -500,6 +510,11 @@ function animate(currentTime) {
 
     // If the game is paused, do not update game logic.
     if (gamePaused) {
+        // Render the scene without updates.
+        renderer.render(scene, camera);
+        // Draw the UI overlay.
+        drawUI();
+        // Exit early to skip game logic.
         return;
     }
 
@@ -581,8 +596,6 @@ function animate(currentTime) {
                 enemy.position.z = (Math.random() - 0.5) * 50;
                 // Increment the score.
                 score += 10;
-                // Update the score display.
-                scoreElement.textContent = 'Score: ' + score;
                 // Break the inner loop since the projectile is gone.
                 break;
             }
@@ -613,22 +626,8 @@ function animate(currentTime) {
             enemyProjectiles.splice(i, 1);
             // Decrease player health.
             health -= 10;
-            // Update health display.
-            healthElement.textContent = 'Health: ' + health;
             // Check if player is dead.
             if (health <= 0) {
-                // Get the game over screen element.
-                const gameOverScreen = document.getElementById('gameOverScreen');
-                // Get the final score element.
-                const finalScoreElement = document.getElementById('finalScore');
-                // Get the restart button element.
-                const restartButton = document.getElementById('restartButton');
-
-                // Display the game over screen.
-                gameOverScreen.style.display = 'block';
-                // Update the final score display.
-                finalScoreElement.textContent = 'Final Score: ' + score;
-
                 // Determine if the current score qualifies for the high score list.
                 const qualifies = highScores.length < MAX_HIGH_SCORES || score > Math.min(...highScores.map(entry => entry.score));
                 // Check if the score qualifies for the top five.
@@ -644,21 +643,14 @@ function animate(currentTime) {
                     // Save high scores to local storage.
                     saveHighScores();
                 }
-                // Display high scores.
-                displayHighScores();
-
                 // Stop the animation loop.
                 gamePaused = true;
+                // Indicate that the game has ended.
+                gameOver = true;
                 // Stop the soundtrack when the game ends.
                 stopSoundtrack();
                 // Release the mouse pointer.
                 document.exitPointerLock();
-
-                // Add event listener for restart button.
-                restartButton.addEventListener('click', () => {
-                    // Reload the page to restart the game.
-                    location.reload();
-                });
             }
         }
     }
@@ -721,6 +713,8 @@ function animate(currentTime) {
 
     // Render the scene from the camera's perspective.
     renderer.render(scene, camera);
+    // Draw the UI overlay after rendering.
+    drawUI();
 }
 
 // Start the animation loop.
@@ -729,18 +723,13 @@ animate();
 // Load high scores when the script starts.
 loadHighScores();
 
-// Get the start screen element.
-const startScreen = document.getElementById('startScreen');
-// Get the start button element.
-const startButton = document.getElementById('startButton');
-
 // Initially pause the game.
 gamePaused = true;
 
-// Add event listener for the start button.
-startButton.addEventListener('click', () => {
-    // Hide the start screen.
-    startScreen.style.display = 'none';
+// Function to start the game.
+function startGame() {
+    // Hide the start screen by setting the started flag.
+    gameStarted = true;
     // Unpause the game.
     gamePaused = false;
     // Start the soundtrack.
@@ -753,4 +742,63 @@ startButton.addEventListener('click', () => {
         // Set the last shot time for the enemy to the current time.
         enemy.lastShotTime = Date.now();
     });
-});
+}
+
+// Function to draw the user interface.
+function drawUI() {
+    // Clear the entire UI canvas.
+    uiContext.clearRect(0, 0, uiCanvas.width, uiCanvas.height);
+    // Set the text color.
+    uiContext.fillStyle = 'black';
+    // Set the font style.
+    uiContext.font = '20px sans-serif';
+    // Draw the score text.
+    uiContext.fillText('Score: ' + score, 10, 30);
+    // Draw the health text.
+    uiContext.fillText('Health: ' + health, 10, 60);
+    // Draw the FPS text.
+    uiContext.fillText('FPS: ' + fps, uiCanvas.width - 100, 30);
+    // Check if the game has not started.
+    if (!gameStarted && !gameOver) {
+        // Set a translucent background color.
+        uiContext.fillStyle = 'rgba(0,0,0,0.8)';
+        // Draw the background rectangle.
+        uiContext.fillRect(uiCanvas.width / 2 - 150, uiCanvas.height / 2 - 100, 300, 200);
+        // Set the text color for the title.
+        uiContext.fillStyle = 'white';
+        // Set the large font for the title.
+        uiContext.font = '30px sans-serif';
+        // Draw the game title.
+        uiContext.fillText('ShootyMcToothy', uiCanvas.width / 2 - 120, uiCanvas.height / 2 - 40);
+        // Set the font for the prompt.
+        uiContext.font = '20px sans-serif';
+        // Draw the start prompt.
+        uiContext.fillText('Click to start', uiCanvas.width / 2 - 70, uiCanvas.height / 2 + 20);
+    }
+    // Check if the game is over.
+    if (gameOver) {
+        // Set a translucent background color.
+        uiContext.fillStyle = 'rgba(0,0,0,0.8)';
+        // Draw the background rectangle.
+        uiContext.fillRect(uiCanvas.width / 2 - 150, uiCanvas.height / 2 - 100, 300, 200);
+        // Set the text color for the game over text.
+        uiContext.fillStyle = 'white';
+        // Set the large font for the header.
+        uiContext.font = '30px sans-serif';
+        // Draw the game over header.
+        uiContext.fillText('Game Over!', uiCanvas.width / 2 - 95, uiCanvas.height / 2 - 60);
+        // Set the font for the score.
+        uiContext.font = '20px sans-serif';
+        // Draw the final score text.
+        uiContext.fillText('Final Score: ' + score, uiCanvas.width / 2 - 80, uiCanvas.height / 2 - 20);
+        // Get the list of high scores.
+        const scores = displayHighScores();
+        // Iterate over each high score.
+        for (let i = 0; i < scores.length; i++) {
+            // Draw the current high score line.
+            uiContext.fillText(scores[i], uiCanvas.width / 2 - 80, uiCanvas.height / 2 + 20 + i * 20);
+        }
+        // Draw the restart prompt.
+        uiContext.fillText('Click to restart', uiCanvas.width / 2 - 80, uiCanvas.height / 2 + 20 + scores.length * 20 + 20);
+    }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -134,14 +134,33 @@ function displayHighScores() {
 let score = 0;
 // Initialize player health.
 let health = 100;
-// Get the UI canvas element.
-const uiCanvas = document.getElementById('uiCanvas');
-// Set the UI canvas size to match the window size.
+// Create an offscreen canvas for rendering UI textures.
+const uiCanvas = document.createElement('canvas');
+// Set the width of the offscreen canvas.
 uiCanvas.width = window.innerWidth;
-// Set the height of the UI canvas.
+// Set the height of the offscreen canvas.
 uiCanvas.height = window.innerHeight;
-// Get the 2D drawing context from the UI canvas.
+// Get the 2D context from the offscreen canvas.
 const uiContext = uiCanvas.getContext('2d');
+// Create a texture from the offscreen canvas.
+const uiTexture = new THREE.CanvasTexture(uiCanvas);
+// Create a sprite material using the texture.
+const uiMaterial = new THREE.SpriteMaterial({ map: uiTexture, depthTest: false });
+// Create a sprite to display the UI.
+const uiSprite = new THREE.Sprite(uiMaterial);
+// Position the sprite slightly in front of the camera.
+uiSprite.position.set(0, 0, -1);
+// Add the sprite to the camera so it stays fixed on screen.
+camera.add(uiSprite);
+// Function to update the sprite scale on resize.
+function updateUIScale() {
+    // Calculate the visible height at a depth of one unit.
+    const height = 2 * Math.tan(THREE.MathUtils.degToRad(camera.fov / 2));
+    // Set the sprite scale to cover the view.
+    uiSprite.scale.set(height * camera.aspect, height, 1);
+}
+// Call the scale update once at startup.
+updateUIScale();
 
 // Variables for FPS calculation.
 let lastFrameTime = 0;
@@ -402,10 +421,12 @@ function onWindowResize() {
     camera.updateProjectionMatrix();
     // Set the size of the renderer to the new window size.
     renderer.setSize(window.innerWidth, window.innerHeight);
-    // Update the UI canvas width.
+    // Update the offscreen canvas width.
     uiCanvas.width = window.innerWidth;
-    // Update the UI canvas height.
+    // Update the offscreen canvas height.
     uiCanvas.height = window.innerHeight;
+    // Update the UI sprite scale for the new aspect ratio.
+    updateUIScale();
 }
 
 // The function to create a projectile.
@@ -813,4 +834,6 @@ function drawUI() {
         // Draw the restart prompt.
         uiContext.fillText('Click to restart', uiCanvas.width / 2 - 80, uiCanvas.height / 2 + 20 + scores.length * 20 + 20);
     }
+    // Inform Three.js that the texture has changed.
+    uiTexture.needsUpdate = true;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -780,7 +780,7 @@ function drawUI() {
         // Set a translucent background color.
         uiContext.fillStyle = 'rgba(0,0,0,0.8)';
         // Draw the background rectangle.
-        uiContext.fillRect(uiCanvas.width / 2 - 150, uiCanvas.height / 2 - 100, 300, 200);
+        uiContext.fillRect(uiCanvas.width / 2 - 150, uiCanvas.height / 2 - 150, 300, 300);
         // Set the text color for the game over text.
         uiContext.fillStyle = 'white';
         // Set the large font for the header.

--- a/index.html
+++ b/index.html
@@ -5,23 +5,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
-    <div id="score">Score: 0</div>
-    <div id="health">Health: 100</div>
-    <div id="fpsCounter">FPS: 0</div>
-
-    <div id="startScreen">
-        <h1>ShootyMcToothy</h1>
-        <p>Shoot the baddies!</p>
-        <button id="startButton">Click to start</button>
-    </div>
-
-    <div id="gameOverScreen" style="display: none;">
-        <h1>Game Over!</h1>
-        <p id="finalScore"></p>
-        <h2>High Scores</h2>
-        <ul id="highScoresList"></ul>
-        <button id="restartButton">Restart</button>
-    </div>
+    <canvas id="uiCanvas"></canvas>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="assets/js/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
-    <canvas id="uiCanvas"></canvas>
-
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="assets/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- render game UI on the canvas instead of in HTML
- keep canvas overlay sized with the window
- begin and restart game from canvas clicks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687146676784832393884c18525972e1