### PR TITLE
Add damage sound on health loss

### DIFF
--- a/assets/js/audio.js
+++ b/assets/js/audio.js
@@ -161,6 +161,32 @@ function playHealthPackSound() {
     oscillator.stop(audioContext.currentTime + 0.2);
 }
 
+// The function to play the damage sound.
+function playDamageSound() {
+    // Create an oscillator for the hurt tone.
+    const oscillator = audioContext.createOscillator();
+    // Create a gain node for volume control.
+    const gainNode = audioContext.createGain();
+    // Use a sawtooth wave for a harsh sound.
+    oscillator.type = 'sawtooth';
+    // Start the frequency high to grab attention.
+    oscillator.frequency.setValueAtTime(600, audioContext.currentTime);
+    // Sweep the frequency downward quickly.
+    oscillator.frequency.exponentialRampToValueAtTime(300, audioContext.currentTime + 0.2);
+    // Set the initial volume of the sound.
+    gainNode.gain.setValueAtTime(0.3, audioContext.currentTime);
+    // Fade the volume out rapidly.
+    gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + 0.2);
+    // Connect the oscillator to the gain node.
+    oscillator.connect(gainNode);
+    // Connect the gain node to the master volume control.
+    gainNode.connect(masterGain);
+    // Start the oscillator immediately.
+    oscillator.start();
+    // Stop the oscillator after the ramp.
+    oscillator.stop(audioContext.currentTime + 0.2);
+}
+
 // The function to start the soundtrack.
 function startSoundtrack() {
     // Resume the audio context if it is suspended.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -769,6 +769,8 @@ function animate(currentTime) {
             enemyProjectiles.splice(i, 1);
             // Decrease player health.
             health -= 10;
+            // Play the damage sound effect.
+            playDamageSound();
             // Check if player is dead.
             if (health <= 0) {
                 // Determine if the current score qualifies for the high score list.

--- a/tests/audioFunctions.test.js
+++ b/tests/audioFunctions.test.js
@@ -10,6 +10,10 @@ test('playHealthPackSound function is defined', () => {
   expect(audioCode).toMatch(/function playHealthPackSound\(\)/);
 });
 
+test('playDamageSound function is defined', () => {
+  expect(audioCode).toMatch(/function playDamageSound\(\)/);
+});
+
 test('startSoundtrack function is defined', () => {
   expect(audioCode).toMatch(/function startSoundtrack\(\)/);
 });


### PR DESCRIPTION
## Summary
- create a new `playDamageSound` audio function
- invoke the damage sound whenever player health decreases
- test that the new function is defined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68722ed134a88323b48ba7bd2ba2395e