### PR TITLE
Add tests for gameplay logic

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+const html = fs.readFileSync('index.html', 'utf8');
+
+test('index includes audio.js script', () => {
+  expect(html).toMatch(/<script src="assets\/js\/audio.js"><\/script>/);
+});
+
+test('index includes game.js script', () => {
+  expect(html).toMatch(/<script src="assets\/js\/game.js"><\/script>/);
+});
+
+test('index includes ui.js script', () => {
+  expect(html).toMatch(/<script src="assets\/js\/ui.js"><\/script>/);
+});

--- a/tests/playGame.test.js
+++ b/tests/playGame.test.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+
+const gameCode = fs.readFileSync('assets/js/game.js', 'utf8');
+
+function extractBody(name) {
+  const match = gameCode.match(new RegExp(`function ${name}\\(\\) {([\\s\\S]*?)\\n}`));
+  return match && match[1];
+}
+
+describe('game play simulation', () => {
+  test('startGame sets flags and enemy timers', () => {
+    const body = extractBody('startGame');
+    const startGame = new Function(
+      'gameStarted',
+      'gamePaused',
+      'startSoundtrack',
+      'document',
+      'enemies',
+      'Date',
+      body + '\nreturn {gameStarted, gamePaused, enemies};'
+    );
+    const startSoundtrack = jest.fn();
+    const document = { body: { requestPointerLock: jest.fn() } };
+    const enemies = [{}, {}];
+    const result = startGame(false, true, startSoundtrack, document, enemies, Date);
+    expect(result.gameStarted).toBe(true);
+    expect(result.gamePaused).toBe(false);
+    expect(startSoundtrack).toHaveBeenCalled();
+    expect(document.body.requestPointerLock).toHaveBeenCalled();
+    result.enemies.forEach(enemy => {
+      expect(enemy.lastShotTime).toBeDefined();
+    });
+  });
+
+  test('togglePause pauses and resumes the game', () => {
+    const body = extractBody('togglePause');
+    const togglePause = new Function(
+      'gamePaused',
+      'startSoundtrack',
+      'stopSoundtrack',
+      'document',
+      body + '\nreturn gamePaused;'
+    );
+    const startSoundtrack = jest.fn();
+    const stopSoundtrack = jest.fn();
+    const document = {
+      body: { requestPointerLock: jest.fn() },
+      exitPointerLock: jest.fn()
+    };
+    let state = togglePause(false, startSoundtrack, stopSoundtrack, document);
+    expect(state).toBe(true);
+    expect(stopSoundtrack).toHaveBeenCalled();
+    expect(document.exitPointerLock).toHaveBeenCalled();
+    state = togglePause(state, startSoundtrack, stopSoundtrack, document);
+    expect(state).toBe(false);
+    expect(startSoundtrack).toHaveBeenCalledTimes(1);
+    expect(document.body.requestPointerLock).toHaveBeenCalled();
+  });
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+const serverCode = fs.readFileSync('server.js', 'utf8');
+
+test('express module is required', () => {
+  expect(serverCode).toMatch(/require\(['\"]express['\"]\)/);
+});
+
+test('static middleware is configured', () => {
+  expect(serverCode).toMatch(/app.use\(express.static\(__dirname\)\)/);
+});
+
+test('server listens on port 3000', () => {
+  expect(serverCode).toMatch(/app.listen\(port/);
+});


### PR DESCRIPTION
## Summary
- add playGame.test.js to simulate starting and pausing the game

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68723d586a9483238b8b642fc4ad574a