### PR TITLE
Add autoplay demo mode

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -253,6 +253,8 @@ let gamePaused = false;
 let gameOver = false;
 // Variable to track if the game has started.
 let gameStarted = false;
+// Variable to indicate autoplay mode is active.
+let autoplay = true;
 // Variable to store the animation frame ID.
 let animationFrameId;
 
@@ -614,6 +616,11 @@ function animate(currentTime) {
 
     // If the game is paused, do not update game logic.
     if (gamePaused) {
+        // Rotate the camera slowly during autoplay.
+        if (autoplay) {
+            // Increase the yaw rotation slightly each frame.
+            yawObject.rotation.y += 0.005;
+        }
         // Render the scene without updates.
         renderer.render(scene, camera);
         // Check if two hundred milliseconds have passed since the last UI update.
@@ -943,6 +950,8 @@ function startGame() {
     gameStarted = true;
     // Unpause the game.
     gamePaused = false;
+    // Disable autoplay mode when the player starts.
+    autoplay = false;
     // Start the soundtrack.
     startSoundtrack();
     // Request pointer lock.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1093,9 +1093,9 @@ function startGame() {
 
 // Function to start the autoplay demo.
 function startAutoplay() {
-    // Hide the start screen by setting the started flag.
-    gameStarted = true;
-    // Ensure the game is not paused.
+    // Keep the start screen visible by leaving the started flag false.
+    gameStarted = false;
+    // Ensure the game is not paused so the AI can run.
     gamePaused = false;
     // Keep autoplay mode enabled for the demo.
     autoplay = true;

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -941,14 +941,28 @@ function animate(currentTime) {
                         saveHighScores();
                     }
                 }
-                // Stop the animation loop.
-                gamePaused = true;
-                // Indicate that the game has ended.
-                gameOver = true;
-                // Stop the soundtrack when the game ends.
-                stopSoundtrack();
-                // Release the mouse pointer.
-                document.exitPointerLock();
+                // Check if autoplay mode is active.
+                if (autoplay) {
+                    // Reset the player health for a fresh demo.
+                    health = 100;
+                    // Reset the score for a clean slate.
+                    score = 0;
+                    // Reset the kill count for consistency.
+                    killCount = 0;
+                    // Restart the autoplay demo.
+                    startAutoplay();
+                    // Clear the game over flag so the overlay does not show.
+                    gameOver = false;
+                } else {
+                    // Stop the animation loop when the player dies.
+                    gamePaused = true;
+                    // Indicate that the game has ended.
+                    gameOver = true;
+                    // Stop the soundtrack when the game ends.
+                    stopSoundtrack();
+                    // Release the mouse pointer.
+                    document.exitPointerLock();
+                }
             }
         }
     }

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -101,8 +101,8 @@ function drawUI() {
         // Draw the start prompt.
         uiContext.fillText('Click to start', uiCanvas.width / 2 - 70, uiCanvas.height / 2 + 20);
     }
-    // Check if the game is over.
-    if (gameOver) {
+    // Check if the game is over while not in autoplay mode.
+    if (gameOver && !autoplay) {
         // Set a translucent background color.
         uiContext.fillStyle = 'rgba(0,0,0,0.8)';
         // Draw the background rectangle with extra height.


### PR DESCRIPTION
## Summary
- introduce `autoplay` flag to rotate the camera before the game starts
- stop autoplay when the player clicks to start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687241a0399483238a2a2bd2809610b0