### PR TITLE
Reset player state on new game and AI death

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1037,6 +1037,13 @@ function resetGameState() {
     });
     // Clear the enemy projectiles array.
     enemyProjectiles.length = 0;
+    // Remove all existing health packs from the scene.
+    healthPacks.forEach(pack => {
+        // Remove this health pack from the scene graph.
+        scene.remove(pack);
+    });
+    // Clear the health packs array.
+    healthPacks.length = 0;
     // Create ten new enemies.
     for (let i = 0; i < 10; i++) {
         // Create a new enemy.


### PR DESCRIPTION
## Summary
- add `resetGameState` helper and use it when starting the game
- reset everything when AI-controlled player dies
- guard call in `startGame` for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68725ba6dc7483238b047513e866bb68