### PR TITLE
Append cache buster to local asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 <html>
 <head>
     <title>ShootyMcToothy</title>
-    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/style.css?v=1">
 </head>
 <body>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-    <script src="assets/js/audio.js"></script>
-    <script src="assets/js/game.js"></script>
-    <script src="assets/js/ai.js"></script>
-    <script src="assets/js/ui.js"></script>
+    <script src="assets/js/audio.js?v=1"></script>
+    <script src="assets/js/game.js?v=1"></script>
+    <script src="assets/js/ai.js?v=1"></script>
+    <script src="assets/js/ui.js?v=1"></script>
 </body>
 </html>

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,17 +3,17 @@ const fs = require('fs');
 const html = fs.readFileSync('index.html', 'utf8');
 
 test('index includes audio.js script', () => {
-  expect(html).toMatch(/<script src="assets\/js\/audio.js"><\/script>/);
+  expect(html).toMatch(/<script src="assets\/js\/audio.js\?v=1"><\/script>/);
 });
 
 test('index includes ai.js script', () => {
-  expect(html).toMatch(/<script src="assets\/js\/ai.js"><\/script>/);
+  expect(html).toMatch(/<script src="assets\/js\/ai.js\?v=1"><\/script>/);
 });
 
 test('index includes game.js script', () => {
-  expect(html).toMatch(/<script src="assets\/js\/game.js"><\/script>/);
+  expect(html).toMatch(/<script src="assets\/js\/game.js\?v=1"><\/script>/);
 });
 
 test('index includes ui.js script', () => {
-  expect(html).toMatch(/<script src="assets\/js\/ui.js"><\/script>/);
+  expect(html).toMatch(/<script src="assets\/js\/ui.js\?v=1"><\/script>/);
 });


### PR DESCRIPTION
## Summary
- append `?v=1` to local assets in `index.html`
- update tests to expect the new asset URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872620116148323a42fe6fd418b1c2f