### PR TITLE
Increase health pack pickup radius

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -318,7 +318,7 @@ const healthPacks = [];
 // Duration before a health pack disappears in milliseconds.
 const healthPackDuration = 30000;
 // Distance within which a health pack can be collected.
-const healthPackPickupRadius = 1.5;
+const healthPackPickupRadius = 3;
 // Create an offscreen canvas for rendering UI textures.
 const uiCanvas = document.createElement('canvas');
 // Set the width of the offscreen canvas.


### PR DESCRIPTION
## Summary
- enlarge health pack pickup radius so packs are easier to collect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872a7263f6483238201ae5572558c6c