### PR TITLE
Fix AI rotation to avoid long spin

### DIFF
--- a/assets/js/ai.js
+++ b/assets/js/ai.js
@@ -196,8 +196,12 @@ function updateAutoplayAI(currentTime) {
         dir.subVectors(predicted, yawObject.position);
         // Calculate the desired yaw to face the predicted position.
         const desiredYaw = Math.atan2(-dir.x, -dir.z);
-        // Smoothly rotate the player toward the desired yaw.
-        yawObject.rotation.y += (desiredYaw - yawObject.rotation.y) * rotationSmoothing;
+        // Calculate the yaw difference between the current rotation and the desired rotation.
+        let deltaYaw = desiredYaw - yawObject.rotation.y;
+        // Wrap the yaw difference to the range negative pi to positive pi.
+        deltaYaw = Math.atan2(Math.sin(deltaYaw), Math.cos(deltaYaw));
+        // Smoothly rotate the player toward the desired yaw using the wrapped difference.
+        yawObject.rotation.y += deltaYaw * rotationSmoothing;
         // Calculate the horizontal distance to the predicted position.
         const horiz = Math.sqrt(dir.x * dir.x + dir.z * dir.z);
         // Calculate the desired pitch toward the predicted position.


### PR DESCRIPTION
## Summary
- correct angle difference when rotating AI towards target

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872ab45b8208323a5cac9d996037caa