### PR TITLE
Add spatial hum for projectiles

### DIFF
--- a/assets/js/audio.js
+++ b/assets/js/audio.js
@@ -277,6 +277,79 @@ function stopSoundtrack() {
     clearInterval(soundtrackInterval);
 }
 
+// Function to attach a spatial hum to a projectile.
+function addHumToProjectile(projectile) {
+    // Create an oscillator node for the hum.
+    const oscillator = audioContext.createOscillator();
+    // Use a sine wave for a smooth tone.
+    oscillator.type = 'sine';
+    // Set the frequency to one hundred hertz for a low hum.
+    oscillator.frequency.value = 100;
+    // Create a gain node to control the hum volume.
+    const gainNode = audioContext.createGain();
+    // Keep the hum volume subtle at five percent.
+    gainNode.gain.value = 0.05;
+    // Create a panner node for spatial audio.
+    const panner = audioContext.createPanner();
+    // Use a linear distance model so volume fades with distance.
+    panner.distanceModel = 'linear';
+    // Set the reference distance to one unit.
+    panner.refDistance = 1;
+    // Connect the oscillator to the gain node.
+    oscillator.connect(gainNode);
+    // Connect the gain node to the panner node.
+    gainNode.connect(panner);
+    // Connect the panner node to the master gain.
+    panner.connect(masterGain);
+    // Start the oscillator immediately.
+    oscillator.start();
+    // Store the audio nodes on the projectile for updates.
+    projectile.hum = { oscillator: oscillator, gain: gainNode, panner: panner };
+}
+
+// Function to stop and remove a projectile's hum.
+function removeHumFromProjectile(projectile) {
+    // Ensure the projectile has a hum before attempting to remove it.
+    if (projectile.hum) {
+        // Stop the oscillator right away.
+        projectile.hum.oscillator.stop();
+        // Disconnect the oscillator from the audio graph.
+        projectile.hum.oscillator.disconnect();
+        // Disconnect the gain node from the audio graph.
+        projectile.hum.gain.disconnect();
+        // Disconnect the panner node from the audio graph.
+        projectile.hum.panner.disconnect();
+        // Clear the hum reference on the projectile.
+        projectile.hum = null;
+    }
+}
+
+// Function to update the audio listener position and orientation.
+function updateAudioListener() {
+    // Set the listener position on the x axis.
+    audioContext.listener.positionX.value = yawObject.position.x;
+    // Set the listener position on the y axis.
+    audioContext.listener.positionY.value = yawObject.position.y;
+    // Set the listener position on the z axis.
+    audioContext.listener.positionZ.value = yawObject.position.z;
+    // Create a vector for the forward direction.
+    const forward = new THREE.Vector3();
+    // Get the camera's forward direction.
+    camera.getWorldDirection(forward);
+    // Set the listener forward x component.
+    audioContext.listener.forwardX.value = forward.x;
+    // Set the listener forward y component.
+    audioContext.listener.forwardY.value = forward.y;
+    // Set the listener forward z component.
+    audioContext.listener.forwardZ.value = forward.z;
+    // Set the listener up x component.
+    audioContext.listener.upX.value = 0;
+    // Set the listener up y component.
+    audioContext.listener.upY.value = 1;
+    // Set the listener up z component.
+    audioContext.listener.upZ.value = 0;
+}
+
 // The function to set the master volume.
 function setVolume(level) {
     // Clamp the level between zero and one.

--- a/assets/js/audio.js
+++ b/assets/js/audio.js
@@ -299,6 +299,20 @@ function stopSoundtrack() {
     clearInterval(soundtrackInterval);
 }
 
+// Function to stop all projectile hums at once.
+function stopAllProjectileHums() {
+    // Loop over each friendly projectile.
+    projectiles.forEach(p => {
+        // Stop and remove the hum from this projectile.
+        removeHumFromProjectile(p);
+    });
+    // Loop over each enemy projectile.
+    enemyProjectiles.forEach(p => {
+        // Stop and remove the hum from this projectile.
+        removeHumFromProjectile(p);
+    });
+}
+
 // Function to attach a spatial hum to a projectile.
 function addHumToProjectile(projectile) {
     // Create a positional audio object using the global listener.

--- a/assets/js/audio.js
+++ b/assets/js/audio.js
@@ -37,18 +37,22 @@ function attachAudioListener(cam) {
     // Add the listener object to the provided camera.
     cam.add(listener);
 }
-// Create a buffer filled with a low hum tone.
+// Create a buffer filled with a rocket engine sound.
 const humBufferLength = audioContext.sampleRate;
 // Create the buffer with one channel lasting one second.
 const humBuffer = audioContext.createBuffer(1, humBufferLength, audioContext.sampleRate);
-// Get the data array from the hum buffer.
+// Get the data array from the engine buffer.
 const humData = humBuffer.getChannelData(0);
-// Fill the buffer with a sine wave at one hundred hertz.
+// Fill the buffer with a layered engine tone.
 for (let i = 0; i < humBufferLength; i++) {
     // Calculate the time for this sample.
     const time = i / audioContext.sampleRate;
-    // Set the sample value using the sine function.
-    humData[i] = Math.sin(2 * Math.PI * 100 * time);
+    // Create the base sawtooth-like waveform using two sine waves.
+    const base = Math.sin(2 * Math.PI * 110 * time) + 0.5 * Math.sin(2 * Math.PI * 220 * time);
+    // Add a small amount of random noise for texture.
+    const noise = (Math.random() * 2 - 1) * 0.2;
+    // Combine the base tone and noise scaled down for a subtle effect.
+    humData[i] = (base / 1.5 + noise) * 0.5;
 }
 // Variable to store the interval ID for the soundtrack loop.
 let soundtrackInterval;

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1447,6 +1447,11 @@ function animate(currentTime) {
                         }
                         // Prompt the player for their name or use a default value.
                         const playerName = prompt('Enter your name:', DEFAULT_PLAYER_NAME) || DEFAULT_PLAYER_NAME;
+                        // Stop any hum that may have restarted after the prompt.
+                        if (typeof stopAllProjectileHums === 'function') {
+                            // Call the function to ensure silence.
+                            stopAllProjectileHums();
+                        }
                         // Add the new score to the high scores array.
                         highScores.push({ name: playerName, score: score });
                         // Sort high scores in descending order.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -717,8 +717,6 @@ function createProjectile() {
         scene.add(rocket);
         // Add the rocket to the projectiles array.
         projectiles.push(rocket);
-        // Attach a spatial hum to the rocket.
-        addHumToProjectile(rocket);
     } else if (currentWeapon === 2) {
         // Create a vector storing the muzzle position for the ray start.
         const start = new THREE.Vector3();
@@ -799,8 +797,6 @@ function createProjectile() {
         scene.add(projectile);
         // Add the bullet to the projectiles array.
         projectiles.push(projectile);
-        // Attach a spatial hum to the bullet.
-        addHumToProjectile(projectile);
     }
     // Play the shooting sound effect only after player interaction.
     if (!autoplay) {

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1440,6 +1440,11 @@ function animate(currentTime) {
                     const qualifies = highScores.length < MAX_HIGH_SCORES || score > Math.min(...highScores.map(entry => entry.score));
                     // Check if the score qualifies for the top five.
                     if (qualifies) {
+                        // Stop all projectile hums so the prompt is silent.
+                        if (typeof stopAllProjectileHums === 'function') {
+                            // Call the function when it exists.
+                            stopAllProjectileHums();
+                        }
                         // Prompt the player for their name or use a default value.
                         const playerName = prompt('Enter your name:', DEFAULT_PLAYER_NAME) || DEFAULT_PLAYER_NAME;
                         // Add the new score to the high scores array.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -710,6 +710,8 @@ function createProjectile() {
         scene.add(rocket);
         // Add the rocket to the projectiles array.
         projectiles.push(rocket);
+        // Attach a spatial hum to the rocket.
+        addHumToProjectile(rocket);
     } else if (currentWeapon === 2) {
         // Create a vector storing the muzzle position for the ray start.
         const start = new THREE.Vector3();
@@ -790,6 +792,8 @@ function createProjectile() {
         scene.add(projectile);
         // Add the bullet to the projectiles array.
         projectiles.push(projectile);
+        // Attach a spatial hum to the bullet.
+        addHumToProjectile(projectile);
     }
     // Play the shooting sound effect only after player interaction.
     if (!autoplay) {
@@ -822,6 +826,8 @@ function createEnemyProjectile(enemy) {
     scene.add(projectile);
     // Add the projectile to the enemy projectiles array.
     enemyProjectiles.push(projectile);
+    // Attach a spatial hum to the enemy projectile.
+    addHumToProjectile(projectile);
 }
 
 // Function to create a health pack at a given position.
@@ -1035,6 +1041,8 @@ function updateEnemySpawn() {
 function animate(currentTime) {
     // Request the next animation frame.
     animationFrameId = requestAnimationFrame(animate);
+    // Update the audio listener position and orientation.
+    updateAudioListener();
 
     // Calculate FPS.
     frameCount++;
@@ -1225,8 +1233,19 @@ function animate(currentTime) {
         const projectile = projectiles[i];
         // Update the projectile's position based on its velocity.
         projectile.position.add(projectile.velocity);
+        // Update the audio position if the projectile has a hum.
+        if (projectile.hum) {
+            // Set the panner x position to the projectile x position.
+            projectile.hum.panner.positionX.value = projectile.position.x;
+            // Set the panner y position to the projectile y position.
+            projectile.hum.panner.positionY.value = projectile.position.y;
+            // Set the panner z position to the projectile z position.
+            projectile.hum.panner.positionZ.value = projectile.position.z;
+        }
         // Remove the projectile if it travels too far from its spawn position.
         if (projectile.position.distanceTo(projectile.spawnPosition) > 100) {
+            // Stop the hum sound for this projectile.
+            removeHumFromProjectile(projectile);
             // Remove the projectile mesh from the scene.
             scene.remove(projectile);
             // Remove the projectile from the projectiles array.
@@ -1265,6 +1284,8 @@ function animate(currentTime) {
             }
             // Detonate the rocket if needed.
             if (explode) {
+                // Stop the hum sound for this projectile.
+                removeHumFromProjectile(projectile);
                 // Remove the rocket mesh from the scene.
                 scene.remove(projectile);
                 // Remove the rocket from the projectiles array.
@@ -1277,6 +1298,8 @@ function animate(currentTime) {
         } else {
             // Remove the projectile if it hits an obstacle.
             if (collidesWithObstacles(projectile.position, 0.5)) {
+                // Stop the hum sound for this projectile.
+                removeHumFromProjectile(projectile);
                 // Remove the projectile mesh from the scene.
                 scene.remove(projectile);
                 // Remove the projectile from the projectiles array.
@@ -1286,6 +1309,8 @@ function animate(currentTime) {
             }
             // Remove the projectile if it leaves the ground plane.
             if (Math.abs(projectile.position.x) > 250 || Math.abs(projectile.position.z) > 250) {
+                // Stop the hum sound for this projectile.
+                removeHumFromProjectile(projectile);
                 // Remove the projectile mesh from the scene.
                 scene.remove(projectile);
                 // Remove the projectile from the projectiles array.
@@ -1301,10 +1326,14 @@ function animate(currentTime) {
             const enemyProjectile = enemyProjectiles[k];
             // Check if the projectile is close to the enemy projectile.
             if (projectile.position.distanceTo(enemyProjectile.position) < 0.5) {
+                // Stop the hum sound for the player projectile.
+                removeHumFromProjectile(projectile);
                 // Remove the player projectile from the scene.
                 scene.remove(projectile);
                 // Remove the player projectile from the array.
                 projectiles.splice(i, 1);
+                // Stop the hum sound for the enemy projectile.
+                removeHumFromProjectile(enemyProjectile);
                 // Remove the enemy projectile from the scene.
                 scene.remove(enemyProjectile);
                 // Remove the enemy projectile from its array.
@@ -1320,6 +1349,8 @@ function animate(currentTime) {
             const enemy = enemies[j];
             // Check if the projectile is close to the enemy.
             if (projectile.position.distanceTo(enemy.position) < 1.5) {
+                // Stop the hum sound for this projectile.
+                removeHumFromProjectile(projectile);
                 // Remove the projectile from the scene.
                 scene.remove(projectile);
                 // Remove the projectile from the array.
@@ -1355,8 +1386,19 @@ function animate(currentTime) {
         const projectile = enemyProjectiles[i];
         // Update the projectile's position based on its velocity.
         projectile.position.add(projectile.velocity);
+        // Update the audio position if the projectile has a hum.
+        if (projectile.hum) {
+            // Set the panner x position to the projectile x position.
+            projectile.hum.panner.positionX.value = projectile.position.x;
+            // Set the panner y position to the projectile y position.
+            projectile.hum.panner.positionY.value = projectile.position.y;
+            // Set the panner z position to the projectile z position.
+            projectile.hum.panner.positionZ.value = projectile.position.z;
+        }
         // Remove the projectile if it travels too far from its spawn position.
         if (projectile.position.distanceTo(projectile.spawnPosition) > 100) {
+            // Stop the hum sound for this projectile.
+            removeHumFromProjectile(projectile);
             // Remove the projectile mesh from the scene.
             scene.remove(projectile);
             // Remove the projectile from the enemy projectiles array.
@@ -1366,6 +1408,8 @@ function animate(currentTime) {
         }
         // Remove the projectile if it hits an obstacle.
         if (collidesWithObstacles(projectile.position, 0.5)) {
+            // Stop the hum sound for this projectile.
+            removeHumFromProjectile(projectile);
             // Remove the projectile mesh from the scene.
             scene.remove(projectile);
             // Remove the projectile from the enemy projectiles array.
@@ -1376,6 +1420,8 @@ function animate(currentTime) {
 
         // Remove the enemy projectile if it leaves the ground plane.
         if (Math.abs(projectile.position.x) > 250 || Math.abs(projectile.position.z) > 250) {
+            // Stop the hum sound for this projectile.
+            removeHumFromProjectile(projectile);
             // Remove the projectile mesh from the scene.
             scene.remove(projectile);
             // Remove the projectile from the enemy projectiles array.
@@ -1386,6 +1432,8 @@ function animate(currentTime) {
 
         // Check for collision with the player.
         if (projectile.position.distanceTo(yawObject.position) < 1) {
+            // Stop the hum sound for this projectile.
+            removeHumFromProjectile(projectile);
             // Remove the projectile from the scene.
             scene.remove(projectile);
             // Remove the projectile from the array.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -506,6 +506,11 @@ function togglePause() {
     if (gamePaused) {
         // Stop the soundtrack loop.
         stopSoundtrack();
+        // Stop all projectile hums so they do not continue while paused.
+        if (typeof stopAllProjectileHums === 'function') {
+            // Call the function when it exists.
+            stopAllProjectileHums();
+        }
         // Release pointer lock to free the mouse.
         document.exitPointerLock();
     }
@@ -1462,6 +1467,11 @@ function animate(currentTime) {
                     gameOver = true;
                     // Stop the soundtrack when the game ends.
                     stopSoundtrack();
+                    // Stop all projectile hums because gameplay has ended.
+                    if (typeof stopAllProjectileHums === 'function') {
+                        // Call the function when it exists.
+                        stopAllProjectileHums();
+                    }
                     // Release the mouse pointer.
                     document.exitPointerLock();
                 }
@@ -1613,6 +1623,11 @@ function resetGameState() {
     verticalVelocity = 0;
     // Set the player as grounded.
     isGrounded = true;
+    // Stop hum sounds for all existing projectiles.
+    if (typeof stopAllProjectileHums === 'function') {
+        // Call the function when it exists.
+        stopAllProjectileHums();
+    }
     // Reset the player position on the x axis.
     yawObject.position.x = 0;
     // Reset the player position on the y axis.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -15,6 +15,8 @@ scene.environment = skyTexture;
 
 // Create a new perspective camera.
 const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+// Attach the audio listener to the camera.
+attachAudioListener(camera);
 // Create a new WebGL renderer.
 const renderer = new THREE.WebGLRenderer();
 // Set the size of the renderer to the window size.
@@ -1041,8 +1043,6 @@ function updateEnemySpawn() {
 function animate(currentTime) {
     // Request the next animation frame.
     animationFrameId = requestAnimationFrame(animate);
-    // Update the audio listener position and orientation.
-    updateAudioListener();
 
     // Calculate FPS.
     frameCount++;
@@ -1233,15 +1233,6 @@ function animate(currentTime) {
         const projectile = projectiles[i];
         // Update the projectile's position based on its velocity.
         projectile.position.add(projectile.velocity);
-        // Update the audio position if the projectile has a hum.
-        if (projectile.hum) {
-            // Set the panner x position to the projectile x position.
-            projectile.hum.panner.positionX.value = projectile.position.x;
-            // Set the panner y position to the projectile y position.
-            projectile.hum.panner.positionY.value = projectile.position.y;
-            // Set the panner z position to the projectile z position.
-            projectile.hum.panner.positionZ.value = projectile.position.z;
-        }
         // Remove the projectile if it travels too far from its spawn position.
         if (projectile.position.distanceTo(projectile.spawnPosition) > 100) {
             // Stop the hum sound for this projectile.
@@ -1386,15 +1377,6 @@ function animate(currentTime) {
         const projectile = enemyProjectiles[i];
         // Update the projectile's position based on its velocity.
         projectile.position.add(projectile.velocity);
-        // Update the audio position if the projectile has a hum.
-        if (projectile.hum) {
-            // Set the panner x position to the projectile x position.
-            projectile.hum.panner.positionX.value = projectile.position.x;
-            // Set the panner y position to the projectile y position.
-            projectile.hum.panner.positionY.value = projectile.position.y;
-            // Set the panner z position to the projectile z position.
-            projectile.hum.panner.positionZ.value = projectile.position.z;
-        }
         // Remove the projectile if it travels too far from its spawn position.
         if (projectile.position.distanceTo(projectile.spawnPosition) > 100) {
             // Stop the hum sound for this projectile.


### PR DESCRIPTION
## Summary
- implement 3D audio support for projectiles
- attach a hum to each projectile and update the listener
- keep hums synchronized with projectile movement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687345d8fd848323bf55953a9caabac2