### PR TITLE
Refactor helper functions

### DIFF
--- a/assets/js/ai.js
+++ b/assets/js/ai.js
@@ -142,10 +142,10 @@ function updateAutoplayAI(currentTime) {
         currentAIDirection = null;
     }
     // Reset the movement keys before applying the AI direction.
-    keys['w'] = false;
-    keys['a'] = false;
-    keys['s'] = false;
-    keys['d'] = false;
+    if (typeof resetMovementKeys === 'function') {
+        // Call the helper function when available.
+        resetMovementKeys();
+    }
     // Apply the current AI movement direction if any.
     if (currentAIDirection) {
         // Set the chosen direction key to true.
@@ -243,10 +243,10 @@ function startAutoplay() {
     // Keep autoplay mode enabled for the demo.
     autoplay = true;
     // Reset enemy shot timers.
-    enemies.forEach(enemy => {
-        // Set the last shot time for the enemy to the current time.
-        enemy.lastShotTime = Date.now();
-    });
+    if (typeof resetEnemyShotTimers === 'function') {
+        // Call the helper function when available.
+        resetEnemyShotTimers();
+    }
 }
 
 // Start the autoplay demo when the script loads.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -279,6 +279,27 @@ const explosions = [];
 // Create an array to store lightning beam meshes.
 const lightningBeams = [];
 
+// Function to reset enemy shot timers for all enemies.
+function resetEnemyShotTimers() {
+    // Loop over each enemy in the array.
+    enemies.forEach(enemy => {
+        // Set the last shot time for this enemy to the current time.
+        enemy.lastShotTime = Date.now();
+    });
+}
+
+// Function to clear all movement key states.
+function resetMovementKeys() {
+    // Clear the forward key state.
+    keys['w'] = false;
+    // Clear the left key state.
+    keys['a'] = false;
+    // Clear the backward key state.
+    keys['s'] = false;
+    // Clear the right key state.
+    keys['d'] = false;
+}
+
 // Create a texture object that will hold the enemy texture.
 const enemyTexture = new THREE.Texture();
 // Create an image element to load the enemy texture.
@@ -1808,7 +1829,10 @@ function startGame() {
     // Request pointer lock.
     document.body.requestPointerLock();
     // Reset movement keys to avoid AI input persisting.
-    if (typeof keys !== 'undefined') {
+    if (typeof resetMovementKeys === 'function') {
+        // Call the helper function when available.
+        resetMovementKeys();
+    } else if (typeof keys !== 'undefined') {
         // Clear the forward key state.
         keys['w'] = false;
         // Clear the left key state.
@@ -1819,10 +1843,15 @@ function startGame() {
         keys['d'] = false;
     }
 
-
     // Reset enemy shot timers.
-    enemies.forEach(enemy => {
-        // Set the last shot time for the enemy to the current time.
-        enemy.lastShotTime = Date.now();
-    });
+    if (typeof resetEnemyShotTimers === 'function') {
+        // Call the helper function when available.
+        resetEnemyShotTimers();
+    } else {
+        // Loop over each enemy in the array.
+        enemies.forEach(enemy => {
+            // Set the last shot time for this enemy to the current time.
+            enemy.lastShotTime = Date.now();
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- add `resetEnemyShotTimers` and `resetMovementKeys` helpers
- call helpers from AI autoplay and game start logic
- keep original behaviour in tests with fallbacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68736c183a788323b9e7164db4ae6251