### PR TITLE
Add point light for rocket explosions

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -330,6 +330,8 @@ const projectiles = [];
 const enemyProjectiles = [];
 // Create an array to store explosion meshes.
 const explosions = [];
+// Create an array to store lights for rocket explosions.
+const explosionLights = [];
 // Create an array to store lightning beam meshes.
 const lightningBeams = [];
 
@@ -1044,6 +1046,16 @@ function explodeRocket(position) {
     explosion.spawnTime = Date.now();
     // Add the explosion mesh to the scene.
     scene.add(explosion);
+    // Create a point light for the explosion flash.
+    const explosionLight = new THREE.PointLight(0xffaa00, 1, 10);
+    // Set the light position to match the explosion.
+    explosionLight.position.copy(position);
+    // Record the spawn time for removal later.
+    explosionLight.spawnTime = Date.now();
+    // Add the explosion light to the scene.
+    scene.add(explosionLight);
+    // Add the explosion light to the explosionLights array.
+    explosionLights.push(explosionLight);
     // Play a spatial sound effect at the explosion position.
     playExplosionSound(position);
     // Add the explosion to the explosions array.
@@ -1738,6 +1750,18 @@ function animate(currentTime) {
             explosions.splice(i, 1);
         }
     }
+    // Update each explosion light and remove old ones.
+    for (let i = explosionLights.length - 1; i >= 0; i--) {
+        // Get the current explosion light.
+        const light = explosionLights[i];
+        // Remove the light after one hundred milliseconds.
+        if (Date.now() - light.spawnTime > 100) {
+            // Remove the light from the scene.
+            scene.remove(light);
+            // Remove the light from the array.
+            explosionLights.splice(i, 1);
+        }
+    }
 
     // Update each lightning beam and remove old ones.
     for (let i = lightningBeams.length - 1; i >= 0; i--) {
@@ -1917,6 +1941,13 @@ function resetGameState() {
     });
     // Clear the explosions array.
     explosions.length = 0;
+    // Remove all existing explosion lights from the scene.
+    explosionLights.forEach(light => {
+        // Remove this light from the scene graph.
+        scene.remove(light);
+    });
+    // Clear the explosion lights array.
+    explosionLights.length = 0;
     // Remove all existing health packs from the scene.
     healthPacks.forEach(pack => {
         // Remove this health pack from the scene graph.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1050,8 +1050,6 @@ function explodeRocket(position) {
     const explosionLight = new THREE.PointLight(0xffaa00, 1, 10);
     // Set the light position to match the explosion.
     explosionLight.position.copy(position);
-    // Enable shadows for this light to add depth.
-    explosionLight.castShadow = true;
     // Record the spawn time for removal later.
     explosionLight.spawnTime = Date.now();
     // Add the explosion light to the scene.

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1050,6 +1050,8 @@ function explodeRocket(position) {
     const explosionLight = new THREE.PointLight(0xffaa00, 1, 10);
     // Set the light position to match the explosion.
     explosionLight.position.copy(position);
+    // Enable shadows for this light to add depth.
+    explosionLight.castShadow = true;
     // Record the spawn time for removal later.
     explosionLight.spawnTime = Date.now();
     // Add the explosion light to the scene.


### PR DESCRIPTION
## Summary
- add explosionLights array to manage rocket explosion lights
- create a brief point light when a rocket explodes
- remove explosion lights during updates and game reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687386a13298832381e038243ed4ae8e